### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/syncorm.js
+++ b/lib/syncorm.js
@@ -6,7 +6,7 @@ var dbOps = require("./dbops"),
 	U = require("lodash"),
 	async = require("async"),
 	pluralize = require('pluralize'),
-	uuid = require('node-uuid'),
+	uuid = require('uuid'),
 	events = require('events'),
 	mk = require('./mk.js');
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "events": "~1.0.2",
     "lodash": "^3.10.1",
     "mysql": "~2.6.2",
-    "node-uuid": "^1.4.3",
     "pluralize": "^1.1.2",
     "prompt": "^0.2.14",
-    "timezone": "0.0.41"
+    "timezone": "0.0.41",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.